### PR TITLE
Define main script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery.loan-calculator",
   "version": "2.0.2",
+  "main": "js/jquery.loan-calculator.js",
   "description": "Amortized Loan Calculator jQuery Plugin",
   "author": "Jorge González",
   "repository": {


### PR DESCRIPTION
This allow third party scripts to require this plugin doing:

`require('jquery.loan-calculator')`